### PR TITLE
Fix for 2038 date bug

### DIFF
--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -9,7 +9,7 @@ ColumnDate::ColumnDate()
 }
 
 void ColumnDate::Append(const std::time_t& value) {
-    data_->Append(static_cast<uint16_t>(value / 86400));
+    data_->Append(static_cast<uint16_t>(value / std::time_t(86400)));
 }
 
 void ColumnDate::Clear() {
@@ -17,7 +17,7 @@ void ColumnDate::Clear() {
 }
 
 std::time_t ColumnDate::At(size_t n) const {
-    return data_->At(n) * 86400;
+    return data_->At(n) * std::time_t(86400);
 }
 
 void ColumnDate::Append(ColumnRef column) {

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -37,7 +37,6 @@ static std::vector<uint64_t> MakeUUIDs() {
          0x3507213c178649f9llu, 0x9faf035d662f60aellu};
 }
 
-
 TEST(ColumnsCase, NumericInit) {
     auto col = std::make_shared<ColumnUInt32>(MakeNumbers());
 
@@ -108,6 +107,15 @@ TEST(ColumnsCase, DateAppend) {
 
     ASSERT_EQ(col2->Size(), 1u);
     ASSERT_EQ(col2->At(0), (now / 86400) * 86400);
+}
+
+TEST(ColumnsCase, Date2038) {
+    auto col1 = std::make_shared<ColumnDate>();
+    std::time_t largeDate(25882ul * 86400ul);
+    col1->Append(largeDate);
+
+    ASSERT_EQ(col1->Size(), 1u);
+    ASSERT_EQ(static_cast<std::uint64_t>(col1->At(0)), 25882ul * 86400ul);
 }
 
 TEST(ColumnsCase, EnumTest) {


### PR DESCRIPTION
On some systems (in my case RH6/gcc6), 86400 is treated as a signed 32-bit quantity and hence for dates > 2038, `data_->At(n) * 86400` becomes negative and the enclosed test fails with this error:

```
.../clickhouse-cpp/ut/columns_ut.cpp:120: Failure
      Expected: static_cast<std::uint64_t>(coll->At(0))
      Which is: 18446744071650789120
To be equal to: 25882ul * 86400ul
      Which is: 2236204800
```

Note that this is the same change as https://github.com/artpaul/clickhouse-cpp/pull/81, but I believe this repo is deemed to be the primary repo for the C++ clickhouse client?